### PR TITLE
APPSCORE-28093 | Changes for enabling new arch

### DIFF
--- a/NowYouSeeReact.podspec
+++ b/NowYouSeeReact.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'NowYouSeeReact'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'View tracking framework for React Native on iOS'
   
   s.description      = <<-DESC

--- a/Source/Classes/NowYouSeeReact.swift
+++ b/Source/Classes/NowYouSeeReact.swift
@@ -26,6 +26,10 @@ extension NowYou {
         // start swizzling
         _ = swizzleRCTViewForTracking
         _ = swizzleRCTScrollViewForTracking
+        
+        // Fabric
+        _ = swizzleRCTViewComponentViewForTracking
+        _ = swizzleRCTScrollViewComponentViewForTracking
 
         #if DEBUG
         // swizzle debug tracker in debug mode

--- a/Source/Classes/NowYouSeeReact.swift
+++ b/Source/Classes/NowYouSeeReact.swift
@@ -28,7 +28,7 @@ extension NowYou {
         _ = swizzleRCTScrollViewForTracking
         
         // Fabric
-        _ = swizzleRCTViewComponentViewForTracking
+        // _ = swizzleRCTViewComponentViewForTracking
         _ = swizzleRCTScrollViewComponentViewForTracking
 
         #if DEBUG

--- a/Source/Classes/React/RCTScrollView+Swizzle.swift
+++ b/Source/Classes/React/RCTScrollView+Swizzle.swift
@@ -37,7 +37,7 @@ extension RCTScrollView {
     /**
      Swizzled implementation of ```init(swizzleEventDispatcher:)```
     */
-    @objc dynamic fileprivate convenience init(swizzleEventDispatcher: RCTEventDispatcher) {
+    @objc dynamic fileprivate convenience init(swizzleEventDispatcher: RCTEventDispatcherProtocol) {
         // call original implementation
         self.init(swizzleEventDispatcher: swizzleEventDispatcher)
 

--- a/Source/Classes/React/RCTScrollViewComponentView+Swizzle.swift
+++ b/Source/Classes/React/RCTScrollViewComponentView+Swizzle.swift
@@ -1,0 +1,47 @@
+//
+//  RCTScrollViewComponentView+Swizzle.swift
+//  
+//
+//  Created by Kabbi Kumar on 25/05/26.
+//
+
+//  Fabric equivalent of RCTScrollView+Swizzle.swift.
+ 
+import Foundation
+import NowYouSeeMe
+                  
+/**
+ Swizzles methods on RCTScrollViewComponentView. lazy var so that it is called only once.
+ - init(frame:)
+*/
+let swizzleRCTScrollViewComponentViewForTracking: Void = {
+    RCTScrollViewComponentView.swizzleScrollMethod(
+        originalSelector: #selector(RCTScrollViewComponentView.init(frame:)),
+        swizzledSelector: #selector(RCTScrollViewComponentView.init(scrollComponentViewTrackingFrame:))
+    )
+}()
+
+extension RCTScrollViewComponentView {
+    fileprivate class func swizzleScrollMethod(originalSelector: Selector, swizzledSelector: Selector) {
+        guard
+            let originalMethod = class_getInstanceMethod(Self.self, originalSelector),
+            let swizzledMethod = class_getInstanceMethod(Self.self, swizzledSelector)
+        else {
+            return
+        }
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+                                       
+    @objc dynamic fileprivate convenience init(scrollComponentViewTrackingFrame frame: CGRect) {
+        // call original implementation
+        self.init(scrollComponentViewTrackingFrame: frame)
+            
+        /**
+         The inner UIScrollView of each RCTScrollViewComponentView should be tracked,
+         so that children are tracked on scroll.
+         Mirrors what RCTScrollView+Swizzle does for Paper's RCTScrollView.
+        */
+        let scrollView = value(forKey: "scrollView") as? UIScrollView
+        scrollView?.trackView()
+    }
+}

--- a/Source/Classes/React/RCTScrollViewComponentView+Swizzle.swift
+++ b/Source/Classes/React/RCTScrollViewComponentView+Swizzle.swift
@@ -41,6 +41,7 @@ extension RCTScrollViewComponentView {
          so that children are tracked on scroll.
          Mirrors what RCTScrollView+Swizzle does for Paper's RCTScrollView.
         */
+        self.trackView()
         scrollView.trackView()
     }
 }

--- a/Source/Classes/React/RCTScrollViewComponentView+Swizzle.swift
+++ b/Source/Classes/React/RCTScrollViewComponentView+Swizzle.swift
@@ -41,7 +41,6 @@ extension RCTScrollViewComponentView {
          so that children are tracked on scroll.
          Mirrors what RCTScrollView+Swizzle does for Paper's RCTScrollView.
         */
-        let scrollView = value(forKey: "scrollView") as? UIScrollView
-        scrollView?.trackView()
+        scrollView.trackView()
     }
 }

--- a/Source/Classes/React/RCTScrollViewComponentViewDecl.h
+++ b/Source/Classes/React/RCTScrollViewComponentViewDecl.h
@@ -5,8 +5,19 @@
 //  Created by Kabbi Kumar on 25/05/26.
 //
 //
-//  Exposes RCTScrollViewComponentView to Swift without requiring C++ Fabric headers.
-//  Same pattern as RCTViewComponentViewDecl.h.
+//  WHY THIS FILE EXISTS                                                                                                                                              
+//  ────────────────────                                                                                                                                              
+//  RCTScrollViewComponentView.h transitively includes C++ Fabric headers                                                                                             
+//  (react/renderer/...). Swift cannot parse C++ — importing the real header                                                                                          
+//  in the bridging header causes a build failure.                                                                                                                    
+//                                                                                                                                                                    
+//  This file acts as a firewall:                                                                                                                                     
+//    __cplusplus defined (.mm files)  → import the real header; full API available                                                                                   
+//    __cplusplus undefined (Swift)    → see only a plain ObjC declaration; no C++                                                                                    
+//                                                                                                                                                                    
+//  The #else declaration is intentionally minimal — only the properties Swift                                                                                        
+//  actually needs are declared. At runtime both paths resolve to the same class,                                                                                     
+//  so there is no ABI mismatch
 //
 #import <UIKit/UIKit.h>
 #ifdef __cplusplus

--- a/Source/Classes/React/RCTScrollViewComponentViewDecl.h
+++ b/Source/Classes/React/RCTScrollViewComponentViewDecl.h
@@ -1,0 +1,17 @@
+//
+//  RCTScrollViewComponentViewDecl.h
+//  
+//
+//  Created by Kabbi Kumar on 25/05/26.
+//
+//
+//  Exposes RCTScrollViewComponentView to Swift without requiring C++ Fabric headers.
+//  Same pattern as RCTViewComponentViewDecl.h.
+//
+#import <UIKit/UIKit.h>
+#ifdef __cplusplus
+#import <React/RCTScrollViewComponentView.h>
+#else
+@interface RCTScrollViewComponentView : UIView
+@end
+#endif

--- a/Source/Classes/React/RCTScrollViewComponentViewDecl.h
+++ b/Source/Classes/React/RCTScrollViewComponentViewDecl.h
@@ -13,5 +13,6 @@
 #import <React/RCTScrollViewComponentView.h>
 #else
 @interface RCTScrollViewComponentView : UIView
+@property (nonatomic, readonly) UIScrollView *scrollView;
 @end
 #endif

--- a/Source/Classes/React/RCTViewComponentView+Swizzle.swift
+++ b/Source/Classes/React/RCTViewComponentView+Swizzle.swift
@@ -1,0 +1,46 @@
+//
+//  RCTViewComponentView+Swizzle.swift
+//  
+//
+//  Created by Kabbi Kumar on 25/05/26.
+//
+
+//  Fabric equivalent of RCTView+Swizzle.swift.
+//
+  
+import Foundation
+import NowYouSeeMe
+    
+/**
+ Swizzles methods on RCTViewComponentView. lazy var so that it is called only once.
+ - init(frame:)
+*/
+let swizzleRCTViewComponentViewForTracking: Void = {
+    RCTViewComponentView.swizzleMethod(
+        originalSelector: #selector(RCTViewComponentView.init(frame:)),
+        swizzledSelector: #selector(RCTViewComponentView.init(componentViewTrackingFrame:))
+    )
+}()
+  
+extension RCTViewComponentView {
+    fileprivate class func swizzleMethod(originalSelector: Selector, swizzledSelector: Selector) {
+        guard
+            let originalMethod = class_getInstanceMethod(Self.self, originalSelector),
+            let swizzledMethod = class_getInstanceMethod(Self.self, swizzledSelector)
+        else {
+            return
+        }
+        method_exchangeImplementations(originalMethod, swizzledMethod)
+    }
+                     
+    @objc dynamic fileprivate convenience init(componentViewTrackingFrame frame: CGRect) {
+        // call original implementation
+        self.init(componentViewTrackingFrame: frame)
+
+        /**
+         Each RCTViewComponentView should be tracked.
+         Mirrors what RCTView+Swizzle does for Paper's RCTView.
+        */
+        trackView()
+    }
+}

--- a/Source/Classes/React/RCTViewComponentViewDecl.h
+++ b/Source/Classes/React/RCTViewComponentViewDecl.h
@@ -4,11 +4,6 @@
 //
 //  Created by Kabbi Kumar on 25/05/26.
 //
-
-//  Exposes RCTViewComponentView to Swift without requiring C++ Fabric headers.
-//  The bridging header is compiled as ObjC (not C++), so it cannot include
-//  RCTViewComponentView.h directly.
-//
 //  - .mm files  (ObjC++): __cplusplus defined -> real RCTViewComponentView header
 //  - Bridging header / Swift (ObjC): __cplusplus undefined -> forward declaration only
 //

--- a/Source/Classes/React/RCTViewComponentViewDecl.h
+++ b/Source/Classes/React/RCTViewComponentViewDecl.h
@@ -1,0 +1,25 @@
+//
+//  RCTViewComponentViewDecl.h
+//  
+//
+//  Created by Kabbi Kumar on 25/05/26.
+//
+
+//  Exposes RCTViewComponentView to Swift without requiring C++ Fabric headers.
+//  The bridging header is compiled as ObjC (not C++), so it cannot include
+//  RCTViewComponentView.h directly.
+//
+//  - .mm files  (ObjC++): __cplusplus defined -> real RCTViewComponentView header
+//  - Bridging header / Swift (ObjC): __cplusplus undefined -> forward declaration only
+//
+//  RCTViewComponentView IS a UIView subclass, so the declaration is
+//  compatible at runtime.
+//
+ #import <UIKit/UIKit.h>
+   
+ #ifdef __cplusplus
+ #import <React/RCTViewComponentView.h>
+ #else
+ @interface RCTViewComponentView : UIView
+ @end
+ #endif

--- a/Source/Classes/React/RCTViewComponentViewDecl.h
+++ b/Source/Classes/React/RCTViewComponentViewDecl.h
@@ -4,11 +4,19 @@
 //
 //  Created by Kabbi Kumar on 25/05/26.
 //
-//  - .mm files  (ObjC++): __cplusplus defined -> real RCTViewComponentView header
-//  - Bridging header / Swift (ObjC): __cplusplus undefined -> forward declaration only
+//  WHY THIS FILE EXISTS
+//  ────────────────────
+//  RCTViewComponentView.h transitively includes C++ Fabric headers
+//  (react/renderer/...). Swift cannot parse C++ — importing the real header
+//  in the bridging header causes a build failure.
 //
-//  RCTViewComponentView IS a UIView subclass, so the declaration is
-//  compatible at runtime.
+//  This file acts as a firewall:
+//    __cplusplus defined (.mm files)  → import the real header; full API available
+//    __cplusplus undefined (Swift)    → see only a plain ObjC declaration; no C++
+//
+//  The #else declaration is intentionally minimal — only the properties Swift
+//  actually needs are declared. At runtime both paths resolve to the same class,
+//  so there is no ABI mismatch.
 //
  #import <UIKit/UIKit.h>
    


### PR DESCRIPTION
**Summary**
Adds Fabric (New Architecture) support to NowYouSeeReact so horizontal and vertical RCTScrollViewComponentView instances register their inner UIScrollView with NowYouSeeMe, matching the existing Paper RCTScrollView+Swizzle behavior. Also adds Swift-safe ObjC declarations for Fabric component views and fixes Paper scroll swizzle compatibility with RCTEventDispatcherProtocol.

**Problem**
On React Native New Architecture, Paper view classes are replaced by Fabric component views:

RCTScrollView → RCTScrollViewComponentView
RCTView → RCTViewComponentView
Existing NowYouSeeReact swizzles only hook Paper inits (RCTScrollView.init(eventDispatcher:), RCTView.init(frame:)), so they never run under Fabric.

Impact: Inner horizontal UIScrollView instances are not registered with NYSM (ScrollTracker). Carousel / RecyclerListView children attach to the wrong parent in the tracker tree (often the vertical scroll), horizontal contentOffset deltas are not propagated, and viewability percentages stay wrong after mount.

**Solution**
1. Fabric scroll tracking (RCTScrollViewComponentView+Swizzle.swift)
Swizzles RCTScrollViewComponentView.init(frame:) (Fabric equivalent of RCTScrollView+Swizzle).
Calls scrollView.trackView() on the inner UIScrollView so ScrollTracker is created and children receive scroll deltas.
2. Enable Fabric scroll swizzle at startup (NowYouSeeReact.swift)
Registers swizzleRCTScrollViewComponentViewForTracking in NowYou.seeReact() alongside existing Paper swizzles.
swizzleRCTViewComponentViewForTracking is included but left commented out — generic Fabric view auto-tracking is not enabled in this PR; only scroll registration is turned on.
3. Swift / C++ bridging headers
Swift cannot import Fabric headers that pull in C++ (react/renderer/...). Added:

RCTScrollViewComponentViewDecl.h — exposes scrollView to Swift; full header in .mm.
RCTViewComponentViewDecl.h — minimal RCTViewComponentView declaration for Swift.

4. Paper compatibility fix (RCTScrollView+Swizzle.swift)
Changes swizzled init parameter type from RCTEventDispatcher to RCTEventDispatcherProtocol for newer React Native versions.

5. Fabric view swizzle (scaffold, not enabled)
RCTViewComponentView+Swizzle.swift mirrors RCTView+Swizzle (trackView() on init) for future use when interop/generic Fabric view tracking is needed.